### PR TITLE
Tests (and other fixes)

### DIFF
--- a/.go.yaml
+++ b/.go.yaml
@@ -4,3 +4,4 @@ deps:
     - loc: github.com/fzzy/radix/redis
     - loc: github.com/mediocregopher/flagconfig
     - loc: github.com/mediocregopher/pubsubch
+    - loc: github.com/stretchr/testify

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ client -> [job job job job] -> consumer
 
   Returns a queue's name or nil if no events were available.
 
-* QSTATUS
+* QSTATUS [queue ...]
 
-  Get the status of all active queues in the database
-
-  Returns an array-reply of queueNames in the format: [queue] [total] [processing]
+  Get the status of the given queues (or all active queues, if none are given)
+  on the system in the format: [queue] total: [total] processing: [processing]

--- a/clients/clients.go
+++ b/clients/clients.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"time"
@@ -23,14 +24,21 @@ func init() {
 	go notifyConsumersEvents()
 }
 
+// Obstensibly a net.Conn, but for testing we don't want to have to set up a
+// real listen socket and all that noise
+type ClientConn interface {
+	io.ReadWriteCloser
+	RemoteAddr() net.Addr
+}
+
 type Client struct {
 	ClientId string
 	queues   []string
-	Conn     net.Conn
+	Conn     ClientConn
 	NotifyCh chan string
 }
 
-func NewClient(conn net.Conn) *Client {
+func NewClient(conn ClientConn) *Client {
 	client := &Client{Conn: conn, queues: []string{}, NotifyCh: make(chan string, 1)}
 
 	respChan := make(chan *Client, 1)

--- a/clients/clients_test.go
+++ b/clients/clients_test.go
@@ -1,10 +1,9 @@
 package clients
 
 import (
-	. "testing"
 	"github.com/stretchr/testify/assert"
+	. "testing"
 )
-
 
 func TestOpenClose(t *T) {
 	client := NewClient(NewFakeClientConn())

--- a/clients/clients_test.go
+++ b/clients/clients_test.go
@@ -1,0 +1,23 @@
+package clients
+
+import (
+	. "testing"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestOpenClose(t *T) {
+	client := NewClient(NewFakeClientConn())
+	assert.NotEqual(t, "", client.ClientId)
+	callCh <- func() {
+		c := activeClients[client.ClientId]
+		assert.Exactly(t, client, c)
+	}
+
+	client.Close()
+	callCh <- func() {
+		c, ok := activeClients[client.ClientId]
+		assert.Nil(t, c)
+		assert.Equal(t, false, ok)
+	}
+}

--- a/clients/consumers_test.go
+++ b/clients/consumers_test.go
@@ -1,0 +1,100 @@
+package clients
+
+import (
+	. "testing"
+	"github.com/fzzy/radix/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"time"
+	
+	"github.com/mc0/redeque/db"
+)
+
+func TestUpdateQueues(t *T) {
+	queues := []string{
+		RandQueueName(),
+		RandQueueName(),
+		RandQueueName(),
+	}
+
+	redisClient, err := db.RedisPool.Get()
+	require.Nil(t, err)
+
+	client := NewClient(NewFakeClientConn())
+	err = client.UpdateQueues(queues)
+	require.Nil(t, err)
+
+	// TODO adding queues happens asyncronously, make this not be the case
+	time.Sleep(1 * time.Second)
+
+	// Make sure the clientId appears in the consumers set for those queues
+	for i := range queues {
+		key := db.ConsumersKey(queues[i])
+		res := redisClient.Cmd("ZRANK", key, client.ClientId)
+		assert.Equal(t, redis.IntegerReply, res.Type, "res: %s", res)
+	}
+
+	err = client.UpdateQueues(queues[1:])
+	require.Nil(t, err)
+
+	// Make sure the first queue had this clientId removed from it
+	key := db.ConsumersKey(queues[0])
+	res := redisClient.Cmd("ZRANK", key, client.ClientId)
+	assert.Equal(t, redis.NilReply, res.Type, "res: %s", res)
+
+	// Make sure the rest of the queues still have it
+	for i := range queues[1:] {
+		key := db.ConsumersKey(queues[1:][i])
+		res := redisClient.Cmd("ZRANK", key, client.ClientId)
+		assert.Equal(t, redis.IntegerReply, res.Type, "res: %s", res)
+	}
+
+	err = client.UpdateQueues([]string{})
+	require.Nil(t, err)
+
+	// Make sure the clientId appears nowhere
+	for i := range queues {
+		key := db.ConsumersKey(queues[i])
+		res := redisClient.Cmd("ZRANK", key, client.ClientId)
+		assert.Equal(t, redis.NilReply, res.Type, "res: %s", res)
+	}
+
+	db.RedisPool.Put(redisClient)
+}
+
+// BUG: This is currently broken, since ZREMRANGEBYSCORE doesn't run on a queue
+// unless it has at least one active client. It should instead run on all
+// existing consumer sets
+func TestStaleCleanup(t *T) {
+	queue := RandQueueName()
+
+	redisClient, err := db.RedisPool.Get()
+	require.Nil(t, err)
+
+	client := NewClient(NewFakeClientConn())
+	err = client.UpdateQueues([]string{queue})
+	require.Nil(t, err)
+
+	// TODO adding queues happens asyncronously, make this not be the case
+	time.Sleep(1 * time.Second)
+
+	// Make sure the queue has this clientId as a consumer
+	key := db.ConsumersKey(queue)
+	res := redisClient.Cmd("ZRANK", key, client.ClientId)
+	assert.Equal(t, redis.IntegerReply, res.Type, "res: %s", res)
+
+	// Remove all knowledge in the outside world about this client
+	callCh <- func() {
+		delete(activeClients, client.ClientId)
+	}
+
+	// Wait for the timeout period and force the consumer updater to run
+	time.Sleep(STALE_CONSUMER_TIMEOUT)
+	ForceUpdateConsumers()
+	time.Sleep(1 * time.Second)
+
+	// Make sure this client is no longer a consumer
+	res = redisClient.Cmd("ZRANK", key, client.ClientId)
+	assert.Equal(t, redis.NilReply, res.Type, "res: %s", res)
+
+}

--- a/clients/fake_client.go
+++ b/clients/fake_client.go
@@ -1,0 +1,39 @@
+package clients
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"net"
+)
+
+// Implements clients.ClientConn, but isn't an actual network connection. Can
+// still be passed into resp.ReadMessage and other things that take in
+// io.Readers and io.Writers. Used for testing here and other places
+type FakeClientConn struct {
+	*bytes.Buffer
+}
+
+func NewFakeClientConn() *FakeClientConn {
+	return &FakeClientConn{
+		bytes.NewBuffer(make([]byte, 0, 1024)),
+	}
+}
+
+func (fconn *FakeClientConn) Close() error {
+	return nil
+}
+
+func (fconn *FakeClientConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+// Kind of an odd place for this, but it has to go somewhere. Returns a random
+// string to use as a queue name. Used for testing in a few places
+func RandQueueName() string {
+	b := make([]byte, 10)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
+}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -376,16 +376,23 @@ func qstatus(client *clients.Client, args []string) error {
 		return err
 	}
 
-	queueNames, err := db.AllQueueNames(redisClient)
-	if err != nil {
-		writeServerErr(conn, err)
-		return err
+	var queueNames []string
+
+	if len(args) == 0 {
+		queueNames, err = db.AllQueueNames(redisClient)
+		if err != nil {
+			writeServerErr(conn, err)
+			return err
+		}
+	} else {
+		queueNames = args
 	}
 
 	var queueStatuses []string
 
 	for i := range queueNames {
 		queueName := queueNames[i]
+
 		claimedCount := 0
 		availableCount := 0
 		totalCount := 0
@@ -407,7 +414,7 @@ func qstatus(client *clients.Client, args []string) error {
 
 		totalCount = availableCount + claimedCount
 
-		queueStatus := fmt.Sprintf("%s %d %d", queueName, totalCount, claimedCount)
+		queueStatus := fmt.Sprintf("%s total: %d processing: %d", queueName, totalCount, claimedCount)
 		queueStatuses = append(queueStatuses, queueStatus)
 	}
 

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -1,0 +1,177 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/fzzy/radix/redis/resp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"runtime/debug"
+	. "testing"
+	"time"
+
+	"github.com/mc0/redeque/clients"
+)
+
+func readAndAssertStr(t *T, client *clients.Client, expected string) {
+	m, err := resp.ReadMessage(client.Conn)
+	require.Nil(t, err, "stack:\n%s", debug.Stack())
+	s, err := m.Str()
+	require.Nil(t, err, "stack:\n%s", debug.Stack())
+	assert.Equal(t, expected, s, "m: %v stack:\n%s", m, debug.Stack())
+}
+
+func readAndAssertInt(t *T, client *clients.Client, expected int64) {
+	m, err := resp.ReadMessage(client.Conn)
+	require.Nil(t, err, "stack:\n%s", debug.Stack())
+	i, err := m.Int()
+	require.Nil(t, err, "stack:\n%s", debug.Stack())
+	assert.Equal(t, expected, i, "m: %v stack:\n%s", m, debug.Stack())
+}
+
+func readAndAssertNil(t *T, client *clients.Client) {
+	m, err := resp.ReadMessage(client.Conn)
+	require.Nil(t, err, "stack:\n%s", debug.Stack())
+	assert.Equal(t, resp.Nil, m.Type, "m: %v stack:\n%s", m, debug.Stack())
+}
+
+func readAndAssertArr(t *T, client *clients.Client, expected []string) {
+	m, err := resp.ReadMessage(client.Conn)
+	require.Nil(t, err, "stack:\n%s", debug.Stack())
+
+	arr, err := m.Array()
+	require.Nil(t, err, "stack:\n%s", debug.Stack())
+	require.Equal(t, len(expected), len(arr), "stack:\n%s", debug.Stack())
+
+	for i := range expected {
+		s, err := arr[i].Str()
+		require.Nil(t, err, "stack:\n%s", debug.Stack())
+		assert.Equal(t, expected[i], s, "m: %v stack:\n%s", m, debug.Stack())
+	}
+}
+
+func qstatusLine(queue string, totalCount, claimedCount int) string {
+	return fmt.Sprintf("%s total: %d processing: %d", queue, totalCount, claimedCount)
+}
+
+func newClient() *clients.Client {
+	return clients.NewClient(clients.NewFakeClientConn())
+}
+
+func TestPing(t *T) {
+	client := newClient()
+	ping(client, []string{})
+	readAndAssertStr(t, client, "PONG")
+}
+
+func TestQRegister(t *T) {
+	client := newClient()
+	queues := []string{
+		clients.RandQueueName(),
+		clients.RandQueueName(),
+	}
+	qregister(client, queues)
+	readAndAssertStr(t, client, "OK")
+}
+
+// Test adding jobs and removing them
+func TestBasicFunctionality(t *T) {
+	client := newClient()
+	queue := clients.RandQueueName()
+	jobs := []struct{ eventId, job string }{
+		{"0", "foo"},
+		{"1", "bar"},
+		{"2", "baz"},
+	}
+
+	for i := range jobs {
+		qlpush(client, []string{queue, jobs[i].eventId, jobs[i].job})
+		readAndAssertStr(t, client, "OK")
+	}
+
+	for i := range jobs {
+		qrpop(client, []string{queue})
+		readAndAssertArr(t, client, []string{jobs[i].eventId, jobs[i].job})
+
+		qrem(client, []string{queue, jobs[i].eventId})
+		readAndAssertInt(t, client, 1)
+	}
+}
+
+func TestQStatus(t *T) {
+	client := newClient()
+	queues := []string{
+		clients.RandQueueName(),
+		clients.RandQueueName(),
+	}
+
+	qstatus(client, queues)
+	readAndAssertArr(t, client, []string{
+		qstatusLine(queues[0], 0, 0),
+		qstatusLine(queues[1], 0, 0),
+	})
+}
+
+func TestPeeks(t *T) {
+	client := newClient()
+	queue := clients.RandQueueName()
+	jobs := []struct{ eventId, job string }{
+		{"0", "foo"},
+		{"1", "bar"},
+		{"2", "baz"},
+	}
+	jobFirst := jobs[0]
+	jobLast := jobs[len(jobs)-1]
+
+	for i := range jobs {
+		qlpush(client, []string{queue, jobs[i].eventId, jobs[i].job})
+		readAndAssertStr(t, client, "OK")
+	}
+
+	qrpeek(client, []string{queue})
+	readAndAssertArr(t, client, []string{jobFirst.eventId, jobFirst.job})
+
+	qlpeek(client, []string{queue})
+	readAndAssertArr(t, client, []string{jobLast.eventId, jobLast.job})
+
+	// Make sure the actual status of the queue hasn't been affected
+	qstatus(client, []string{queue})
+	readAndAssertArr(t, client, []string{qstatusLine(queue, len(jobs), 0)})
+}
+
+func TestRPush(t *T) {
+	client := newClient()
+	queue := clients.RandQueueName()
+
+	qlpush(client, []string{queue, "0", "foo"})
+	readAndAssertStr(t, client, "OK")
+
+	qrpush(client, []string{queue, "1", "bar"})
+	readAndAssertStr(t, client, "OK")
+
+	qrpeek(client, []string{queue})
+	readAndAssertArr(t, client, []string{"1", "bar"})
+
+	qstatus(client, []string{queue})
+	readAndAssertArr(t, client, []string{qstatusLine(queue, 2, 0)})
+}
+
+func TestQNotify(t *T) {
+	client := newClient()
+	queue := clients.RandQueueName()
+
+	qregister(client, []string{queue})
+	readAndAssertStr(t, client, "OK")
+
+	qnotify(client, []string{"1"})
+	readAndAssertNil(t, client)
+
+	// Spawn a routine which will trigger a notify. We don't need to read the
+	// response of the QLPUSH, it'll all just get garbage collected later
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		qlpush(newClient(), []string{queue, "0", "foo"})
+	}()
+
+	qnotify(client, []string{"10"})
+	readAndAssertStr(t, client, queue)
+}

--- a/db/db.go
+++ b/db/db.go
@@ -37,7 +37,7 @@ func AllQueueNames(redisClient *redis.Client) ([]string, error) {
 	var queueNames []string
 	var err error
 
-	queueKeysReply := redisClient.Cmd("KEYS", queueKey("*", "items"))
+	queueKeysReply := redisClient.Cmd("KEYS", ItemsKey("*"))
 	if queueKeysReply.Err != nil {
 		err = fmt.Errorf("ERR keys redis replied %q", queueKeysReply.Err)
 		return queueNames, err

--- a/db/db_scanner.go
+++ b/db/db_scanner.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"github.com/fzzy/radix/redis"
+	"github.com/mc0/redeque/log"
+)
+
+type ScanResult struct {
+	Result string
+	Err    error
+}
+
+// Performs a SCAN command on the given redis client, returning a channel which
+// will output each individual scan result. The channel will be closed if there
+// are no more results (the scan is over). If there is an error mid-scan the Err
+// field of the ScanResult will be filled with that error and the channel will
+// be closed. The redis client passed in should not be used again until the
+// channel is closed.
+func Scan(redisClient *redis.Client, pattern string) <-chan *ScanResult {
+	retCh := make(chan *ScanResult)
+	go func() {
+		defer close(retCh)
+		cursor := "0"
+		for {
+			r := redisClient.Cmd("SCAN", cursor, "MATCH", pattern)
+			if r.Type == redis.ErrorReply {
+				retCh <- &ScanResult{Err: r.Err}
+				return
+			}
+			results, err := r.Elems[1].List()
+			if err != nil {
+				retCh <- &ScanResult{Err: err}
+				return
+			}
+			for i := range results {
+				retCh <- &ScanResult{Result: results[i]}
+			}
+			if cursor, err = r.Elems[0].Str(); err != nil {
+				retCh <- &ScanResult{Err: err}
+				return
+			} else if cursor == "0" {
+				return
+			}
+		}
+	}()
+
+	return retCh
+}
+
+// Same as Scan, except it handles Get'ing and Put'ing the connection on the
+// pool, and doesn't return errors (it logs them instead). It will close the channel when there are no
+// more results to give, or when there has been an error
+func ScanWrapped(pattern string) <-chan string {
+	retCh := make(chan string)
+	go func() {
+		defer close(retCh)
+		redisClient, err := RedisPool.Get()
+		if err != nil {
+			log.L.Printf("starting ScanWrapped(%s): %s", pattern, err)
+			return
+		}
+
+		for r := range Scan(redisClient, pattern) {
+			if r.Err != nil {
+				log.L.Printf("ScanWrapped(%s): %s", pattern, err)
+				return
+			}
+			retCh <- r.Result
+		}
+
+		RedisPool.Put(redisClient)
+	}()
+	return retCh
+}

--- a/db/db_scanner_test.go
+++ b/db/db_scanner_test.go
@@ -1,0 +1,37 @@
+package db
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	. "testing"
+)
+
+func TestScan(t *T) {
+	redisClient, err := RedisPool.Get()
+	require.Nil(t, err)
+
+	keys := map[string]struct{}{}
+	for i := 0; i < 100; i++ {
+		keys[fmt.Sprintf("scantest:%d", i)] = struct{}{}
+	}
+
+	for key := range keys {
+		require.Nil(t, redisClient.Cmd("SET", key, key).Err)
+	}
+
+	output := map[string]struct{}{}
+	for r := range Scan(redisClient, "scantest:*") {
+		require.Nil(t, r.Err)
+		output[r.Result] = struct{}{}
+	}
+	assert.Equal(t, keys, output)
+
+	// Also test ScanWrapped while we're here
+	output2 := map[string]struct{}{}
+	for r := range ScanWrapped("scantest:*") {
+		output2[r] = struct{}{}
+	}
+	assert.Equal(t, keys, output2)
+
+}

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -1,4 +1,7 @@
-package main
+// Periodically runs through all the queues and finds jobs which are in the
+// claimed queue but have been abandoned and puts them back in the unclaimed
+// queue
+package restore
 
 import (
 	"github.com/fzzy/radix/redis"
@@ -8,17 +11,15 @@ import (
 	"github.com/mc0/redeque/log"
 )
 
-func setupRestoringTimedOutEvents() {
-	go restoreTimedOutEvents()
-}
+func init() {
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
 
-func restoreTimedOutEvents() {
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
-
-	for _ = range ticker.C {
-		validateClaimedEvents()
-	}
+		for _ = range ticker.C {
+			validateClaimedEvents()
+		}
+	}()
 }
 
 func validateClaimedEvents() {

--- a/server.go
+++ b/server.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/mc0/redeque/clients"
 	"github.com/mc0/redeque/commands"
@@ -53,11 +52,6 @@ func serveClient(client *clients.Client) {
 
 outer:
 	for {
-		err := conn.SetReadDeadline(time.Now().Add(1 * time.Second))
-		if err != nil {
-			return
-		}
-
 		m, err := resp.ReadMessage(conn)
 		var command string
 		var args []string

--- a/server.go
+++ b/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mc0/redeque/commands"
 	"github.com/mc0/redeque/config"
 	"github.com/mc0/redeque/log"
+	_ "github.com/mc0/redeque/restore"
 )
 
 func main() {
@@ -23,8 +24,6 @@ func main() {
 	log.L.Printf("listening on %s", config.ListenAddr)
 
 	incomingConns := make(chan net.Conn)
-
-	setupRestoringTimedOutEvents()
 
 	go acceptConns(server, incomingConns)
 


### PR DESCRIPTION
Major changes in this PR, besides the addition of tests:

* Refactored the consumers code. One of the tests showed it not actually working properly (not cleaning up consumer set for queues that didn't have any active consumers), and I wanted to refactor it to be a bit more readable and testable anyway. So I did that.

* Made `QSTATUS` take in an optional list of queue names. This was mostly to aid in testing, but it could be useful to users too. Also, made the output be more human readable.

* Made `clients.Client` hold onto a `ClientConn` instead of a `net.Conn`. A `ClientConn` is an interface I made up which encompasses all the features we need out of a `net.Conn`, while still allowing us to essentially fake a network connection in our tests.