### PR TITLE
Fixes

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -134,13 +134,6 @@ func ItemLockKey(queueName, eventID string) string {
 	return queueKey(queueName, "lock", eventID)
 }
 
-// ItemRestoreKey returns the key which is used as a lock when restoring an
-// eventID from the claimed to unclaimed queues, so that other running okq
-// processes don't try to do the same
-func ItemRestoreKey(queueName, eventID string) string {
-	return queueKey(queueName, "restore", eventID)
-}
-
 // QueueChannelNameKey returns the name of the pubsub channel used to broadcast
 // events for the given queue
 func QueueChannelNameKey(queueName string) string {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mc0/okq/db"
 	"github.com/mc0/okq/log"
-	"github.com/mediocregopher/radix.v2/redis"
 )
 
 func init() {
@@ -66,18 +65,6 @@ func validateClaimedEvents() {
 }
 
 func restoreEventToQueue(queueName string, eventID string) error {
-	// Set a lock for restoring
-	restoreKey := db.ItemRestoreKey(queueName, eventID)
-	reply := db.Inst.Cmd("SET", restoreKey, 1, "EX", 10, "NX")
-	if reply.Err != nil {
-		log.L.Printf("set failed for restoring %q", reply.Err)
-		return reply.Err
-	}
-	if reply.IsType(redis.Nil) {
-		log.L.Debug("%s restored already", eventID)
-		return nil
-	}
-
 	unclaimedKey := db.UnclaimedKey(queueName)
 	claimedKey := db.ClaimedKey(queueName)
 	r := db.Inst.Lua("LREMRPUSH", 2, claimedKey, unclaimedKey, eventID)


### PR DESCRIPTION
* Remove the restore lock key, it's no longer needed for anything since we're using that atomic lua operation now

* Make sure that queues which have only a consumer (but no events) also show up in the return from `db.AllQueueNames`