### PR TITLE
Qinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,59 @@ client -> [event event event event] -> consumer
 
 * QSTATUS [queue ...]
 
-  Get the status of the given queues (or all active queues, if none are given)
-  on the system in the format:
+  Get information about the given queues (or all active queues, if none are
+  given) on the system.
 
-    [queue] total: [total] processing: [processing] consumers: [consumers]
+  An array of arrays will be returned, for example:
+
+  ```
+  > QSTATUS foo bar
+  1) 1) "foo"
+     2) (integer) 2
+     3) (integer) 1
+     4) (integer) 3
+  2) 1) "bar"
+     2) (integer) 43
+     3) (integer) 0
+     4) (integer) 0
+  ```
+
+  The integer values returned indicate (respectively):
+
+  * total - The number of events currently held by okq for the queue, both
+    those that are awaiting a consumer and those which are actively held by a
+    consumer
+
+  * processing - The number of events for the queue which are being actively
+    held by a consumer
+
+  * consumers - The number of consumers currently registered for the queue
+
+  The returned order will match the order of the queues given in the call. If no
+  queues are given (and so information on all active queues is being returned)
+  they will be returned in ascending alphabetical order
+
+  *NOTE that there may in the future be more information returned in the
+  sub-arrays returned by this call; do not assume that they will always be of
+  length 4*
+
+* QINFO [queue ...]
+
+  Get human readable information about the given queues (or all active queues,
+  if none are given) on the system in the format:
+
+  This command effectively calls QSTATUS with the given arguments and returns
+  its output in a nicely formatted way. The returned value will be an array of
+  strings, one per queue, each formatted like so:
+
+  ```
+  > QINFO foo bar
+  foo  total: 2   processing: 1  consumers: 3
+  bar  total: 43  processing: 0  consumers: 0
+  ```
+
+  See QSTATUS for the meaning of `total`, `processing`, and `consumers`
+
+  *NOTE that this output is intended to be read by humans and its format may
+  change slightly everytime the command is called. For easily machine readable
+  output of the same data see the QSTATUS command*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-okQ
-=======
+# okq
 
 A simple go-based reliable event queueing with at-least-once support.
 
@@ -8,10 +7,9 @@ This allows swapping connecting directly to the service from any redis client.
 
 [![Build Status](https://travis-ci.org/mc0/okq.svg?branch=master)](https://travis-ci.org/mc0/okq)
 
-Commands
---------
+## Commands
 
-OkQ is modeled as a left-to-right queue. Clients submit events on the left
+okq is modeled as a left-to-right queue. Clients submit events on the left
 side of the queue (with `QLPUSH`, and consumers read off the right side (with
 `QRPOP`).
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -323,7 +323,7 @@ func qnotify(client *clients.Client, args []string) (interface{}, error) {
 		var unclaimedCount int
 		unclaimedCount, err = db.Inst.Cmd("LLEN", unclaimedKey).Int()
 		if err != nil {
-			return nil, fmt.Errorf("QSTATUS LLEN unclaimed): %s", err)
+			return nil, fmt.Errorf("QNOTIFY LLEN unclaimed): %s", err)
 		}
 
 		if unclaimedCount > 0 {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -34,7 +34,7 @@ func readAndAssertInt(t *T, client *clients.Client, expected int64) {
 	rr := redis.NewRespReader(client.Conn)
 	m := rr.Read()
 	require.Nil(t, m.Err, "stack:\n%s", debug.Stack())
-	i, err := m.Int()
+	i, err := m.Int64()
 	require.Nil(t, err, "stack:\n%s", debug.Stack())
 	assert.Equal(t, expected, i, "m: %v stack:\n%s", m, debug.Stack())
 }

--- a/db/db_cluster.go
+++ b/db/db_cluster.go
@@ -64,7 +64,7 @@ func (d *clusterDB) Scan(pattern string) <-chan string {
 }
 
 func (d *clusterDB) Lua(cmd string, numKeys int, args ...interface{}) *redis.Resp {
-	key, err := cluster.KeyFromArgs(args)
+	key, err := redis.KeyFromArgs(args)
 	if err != nil {
 		return redis.NewResp(err)
 	}


### PR DESCRIPTION
Implements issue #21

This commit adds QINFO, which is essentially what QSTATUS used to be but now even prettier, which its columns lining up nicely between lines. QSTATUS is now a nicely machine readable version of that same data returned by QINFO, and in fact QINFO uses QSTATUS as the source of its data. In doing these two changes some large changes to the commands_test.go file were done, in effect making it use QSTATUS instead of QINFO in all the places where it needed to check the overall status of one or more queues.

This PR also includes a few other fixes for problems I ran across in working on this feature.