### PR TITLE
Fix race condition between qrpop and event restoration (Fixes #29)

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -136,6 +136,10 @@ func TestBasicFunctionality(t *T) {
 		Dispatch(client, "qack", []string{queue, events[i].eventID})
 		readAndAssertInt(t, client, 1)
 	}
+
+	// Make sure qrpop on an empty queue does the right thing
+	Dispatch(client, "qrpop", []string{queue})
+	readAndAssertNil(t, client)
 }
 
 func TestQStatus(t *T) {


### PR DESCRIPTION
The issue occurs due to us doing a RPOPLPUSH(unclaimed, claimed), then setting
a lock on the event that comes back from that so that the restoration process
doesn't move the event back to unclaimed. We do these two steps non-atomically,
so in between the restoration script has a chance of moving it back anyway. This
causes things to get weird. The solution was to make a lua script which does the
RPOPLPUSH, then if it gets anything back immediately locks it. This way the
locking is atomic with the getting. While I was in there I made the HGET which
follows also be part of the lua script. It's not strictly necessary, but it
won't hurt, and it'll make things faster.